### PR TITLE
fix inconsistent status in BuildStatus

### DIFF
--- a/gmicloud/_internal/_manager/_artifact_manager.py
+++ b/gmicloud/_internal/_manager/_artifact_manager.py
@@ -401,7 +401,7 @@ class ArtifactManager:
                 artifact = self.get_artifact(artifact_id)
                 if artifact.build_status == BuildStatus.SUCCESS:
                     return
-                elif artifact.build_status in [BuildStatus.FAILED, BuildStatus.TIMEOUT, BuildStatus.CANCELLED]:
+                elif artifact.build_status in [BuildStatus.FAILURE, BuildStatus.TIMEOUT, BuildStatus.CANCELLED]:
                     raise Exception(f"Artifact build failed, status: {artifact.build_status}")
             except Exception as e:
                 logger.error(f"Failed to get artifact, Error: {e}")


### PR DESCRIPTION
In gmicloud/_internal/_enums.py, BuildStatus has FAILURE not FAILED